### PR TITLE
Group inserts and deletes in the same composite Change

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v3.0.0"
 github "Quick/Quick" "v0.8.0"
-github "ReactiveX/RxSwift" "2.1.0"
+github "ReactiveX/RxSwift" "2.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v3.0.0"
 github "Quick/Quick" "v0.8.0"
-github "ReactiveX/RxSwift" "2.4"
+github "ReactiveX/RxSwift" "2.1.0"

--- a/CollectionVariable/CollectionVariable.swift
+++ b/CollectionVariable/CollectionVariable.swift
@@ -127,16 +127,17 @@ public final class CollectionVariable<T> {
     public func replace(subRange: Range<Int>, with elements: [T]) {
         _lock.lock()
         precondition(subRange.startIndex + subRange.count <= _value.count, "Range out of bounds")
-        var insertsComposite: [CollectionChange<T>] = []
-        var deletesComposite: [CollectionChange<T>] = []
+        
+        var compositeChanges: [CollectionChange<T>] = []
+        
         for (index, element) in elements.enumerate() {
             let replacedElement = _value[subRange.startIndex+index]
-            _value.replaceRange(Range<Int>(start: subRange.startIndex+index, end: subRange.startIndex+index+1), with: [element])
-            deletesComposite.append(.Remove(subRange.startIndex + index, replacedElement))
-            insertsComposite.append(.Insert(subRange.startIndex + index, element))
+            let range = subRange.startIndex+index..<subRange.startIndex+index+1
+            _value.replaceRange(range, with: [element])
+            compositeChanges.append(.Remove(subRange.startIndex + index, replacedElement))
+            compositeChanges.append(.Insert(subRange.startIndex + index, element))
         }
-        _changesSubject.onNext(.Composite(deletesComposite))
-        _changesSubject.onNext(.Composite(insertsComposite))
+        _changesSubject.onNext(.Composite(compositeChanges))
         _subject.onNext(_value)
         _lock.unlock()
     }

--- a/CollectionVariableTests/CollectionVariableTests.swift
+++ b/CollectionVariableTests/CollectionVariableTests.swift
@@ -394,7 +394,6 @@ class CollectionVariableTests: QuickSpec {
                                 }
                             default: break
                             }
-                            i++
                         })
                         variable.replace(Range<Int>(start: 0, end: 1), with: ["test3", "test4"])
                     })

--- a/CollectionVariableTests/CollectionVariableTests.swift
+++ b/CollectionVariableTests/CollectionVariableTests.swift
@@ -381,25 +381,15 @@ class CollectionVariableTests: QuickSpec {
                     let array: [String] = ["test1", "test2"]
                     let variable: CollectionVariable<String> = CollectionVariable(array)
                     waitUntil(action: { (done) -> Void in
-                        var i: Int = 0
                         _ = variable.changesObservable.subscribe({ (event) -> Void in
                             switch event {
                             case .Next(let change):
                                 switch change {
                                 case .Composite(let changes):
-                                    if i == 0 { // Removal
-                                        let indexes = changes.map({$0.index()!})
-                                        let elements = changes.map({$0.element()!})
-                                        expect(indexes) == [0, 1]
-                                        expect(elements) == ["test1", "test2"]
-                                    }
-                                    else { // Insertion
-                                        let indexes = changes.map({$0.index()!})
-                                        let elements = changes.map({$0.element()!})
-                                        expect(indexes) == [0, 1]
-                                        expect(elements) == ["test3", "test4"]
-                                        done()
-                                    }
+                                    let indexes = changes.map({$0.index()!})
+                                    let elements = changes.map({$0.element()!})
+                                    expect(indexes) == [0, 0, 1, 1]
+                                    expect(elements) == ["test1", "test3", "test2", "test4"]
                                 default: break
                                 }
                             default: break

--- a/CollectionVariableTests/CollectionVariableTests.swift
+++ b/CollectionVariableTests/CollectionVariableTests.swift
@@ -398,6 +398,7 @@ class CollectionVariableTests: QuickSpec {
                         })
                         variable.replace(Range<Int>(start: 0, end: 1), with: ["test3", "test4"])
                     })
+                    
                 })
                 
             })


### PR DESCRIPTION
This way you will only receive one change `CompositeChange` instead of two (one for deletions and another for inserts).

If you rely on `tableView.beginUpdates()` and `tableView.endUpdates()` it makes more sense this way, it won't work receiving two different events because of this:

```swift
viewModel.collection.asObservable().subscribeNext { [weak self] change in
  self?.tableView.beginUpdates()
  self?.handleCollectionChangeEvent(change)
  self?.tableView.endUpdates()
}

func handleCollectionChangeEvent(change) {
  switch change {
    ... // Do inserts and deletes
  }
}
```

With that example, if you receive the deletions and the inserts separately, it will crash because of the two begin/end loops, one for deletions, and another for insertions, when the collection count hasn't change at all